### PR TITLE
Fix macOS compatibility issues with threading and windowing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,23 @@ A PyTorch memory snapshot viewer alternative to https://docs.pytorch.org/memory_
   maturin dev -r
   ```
 - Specify resolution, log level and directory to your snapshot (which should have `allocations.json` and `elements.db`), and run the application.
-  - Tkinter application (tested on windows and linux)
+  - Tkinter application (tested on Windows, Linux, and macOS)
     ```sh
     python gui.py --log info --res 2400 1000 -d <dir_to_your_snapshot>
     ```
+
+## Platform Notes
+
+### macOS Compatibility
+On macOS, there are threading limitations due to the windowing system requirements:
+- **GUI Panel**: The tkinter GUI (REPL and message panels) works correctly on macOS
+- **3D Viewer Window**: The 3D memory visualization window may not appear due to macOS requiring both the GUI framework (tkinter) and the graphics library (winit) to run on the main thread
+- **Workaround**: The REPL interface remains fully functional for SQL queries even if the 3D viewer doesn't appear
+
+The application automatically detects macOS and adjusts its threading model to prioritize the GUI panel functionality.
+
+### Windows & Linux
+Both the GUI panel and 3D viewer window work normally on Windows and Linux platforms.
 
 ## Notes
 - Minimal dependency is **not** a goal.


### PR DESCRIPTION
This commit addresses the macOS-specific threading limitations where both tkinter and winit require the main thread.

Changes:
- Detect macOS at runtime using platform.system()
- On macOS: Run tkinter GUI on main thread, Rust viewer in background
- On Windows/Linux: Keep original behavior (viewer on main, GUI in background)
- Add comprehensive error handling and user-friendly messages for macOS
- Fix duplicate font registration error by wrapping font creation in try-except
- Update README.md with platform-specific compatibility notes

The GUI panel (REPL and messages) now works correctly on macOS. The 3D viewer window may not appear due to fundamental macOS threading restrictions, but the REPL remains fully functional for SQL queries.

Fixes the NSWindow and EventLoop "must be created on main thread" errors.